### PR TITLE
Add global authentication context for users

### DIFF
--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -5,11 +5,15 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 import WelcomePanel from "../components/WelcomePanel";
+// import { useAuth } from "../contexts/AuthContext";
 import { auth } from "../firebase-config.js";
 
 import styles from "./Auth.module.css";
 
 export default function Auth() {
+  // Example usage of useAuth
+  // const { currentUser } = useAuth();
+
   const router = useRouter();
   const searchParams = useSearchParams();
   const actionExecuted = useRef(false);

--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -1,0 +1,37 @@
+// frontend/src/app/contexts/AuthContext.tsx
+"use client";
+
+import { User, onAuthStateChanged } from "firebase/auth";
+import { createContext, useContext, useEffect, useState } from "react";
+
+import { auth } from "../firebase-config.js";
+
+type AuthContextType = {
+  currentUser: User | null;
+  loading: boolean;
+};
+
+const AuthContext = createContext<AuthContextType>({
+  currentUser: null,
+  loading: true,
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setCurrentUser(user);
+      setLoading(false);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return <AuthContext.Provider value={{ currentUser, loading }}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,7 +2,9 @@ import localFont from "next/font/local";
 import { Toaster } from "react-hot-toast";
 
 import type { Metadata } from "next";
+
 import "./globals.css";
+import { AuthProvider } from "./contexts/AuthContext";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -28,18 +30,20 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <Toaster
-          toastOptions={{
-            style: {
-              boxShadow: "none",
-              backgroundColor: "#FAFFEA",
-              borderRadius: "16",
-              maxWidth: "55ch",
-              border: "1px solid #1c3a29",
-            },
-          }}
-        />
-        {children}
+        <AuthProvider>
+          <Toaster
+            toastOptions={{
+              style: {
+                boxShadow: "none",
+                backgroundColor: "#FAFFEA",
+                borderRadius: "16",
+                maxWidth: "55ch",
+                border: "1px solid #1c3a29",
+              },
+            }}
+          />
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );


### PR DESCRIPTION

## Changes

I added an auth context that allows users to fetch thier current authentication status along with user data (name, email, etc.) from the use of the `useAuth` hook

## Testing

I made an account then logged in then went to the `/auth` page then tested using the hook:
`const {currentUser} = useAuth()`
`console.log(currentUser)`

## Confirmation of Changes

![CleanShot 2025-04-18 at 19 35 00@2x](https://github.com/user-attachments/assets/8c62be48-3479-4114-b9cd-f61848f90070)
