### PR TITLE
Isabel and Sweekrits Issues Addressed

### DIFF
--- a/frontend/src/app/certificate/page.tsx
+++ b/frontend/src/app/certificate/page.tsx
@@ -81,7 +81,7 @@ export default function CertificatePage() {
                 />
 
                 <p className={styles.congrats}>
-                  Congratulations! You’ve officially completed the E-Bike safety course!
+                  Congratulations! You’ve officially completed the E Bike safety course!
                 </p>
 
                 <Image

--- a/frontend/src/app/components/Checkbox/Checkbox.module.css
+++ b/frontend/src/app/components/Checkbox/Checkbox.module.css
@@ -115,7 +115,7 @@
 
 .selectedRectangle {
   height: 114px;
-  width: 631px;
+  width: 100%;
   padding: 1.875rem 1.25rem;
   background-color: #bbd567;
   border-radius: 16px;

--- a/frontend/src/app/components/CreateAccountPanel.tsx
+++ b/frontend/src/app/components/CreateAccountPanel.tsx
@@ -271,6 +271,8 @@ export default function CreateAccountPanel({ setAccountCreated }: CreateAccountP
             trackEmail(formData.email);
           }}
           error={errors.emailError}
+          name="username"
+          autoComplete="username"
         />
         <TextBox
           label="Password"
@@ -285,6 +287,8 @@ export default function CreateAccountPanel({ setAccountCreated }: CreateAccountP
             trackPassword(formData.password);
           }}
           error={errors.passwordError}
+          name="password"
+          autoComplete="current-password"
         />
       </div>
       {errors.otherError && (

--- a/frontend/src/app/components/Mod2Components/BikeMechanic.tsx/BikeMechanic.module.css
+++ b/frontend/src/app/components/Mod2Components/BikeMechanic.tsx/BikeMechanic.module.css
@@ -33,13 +33,15 @@
 
 #svg_container .svg_text p {
   font-family: "DM Sans";
+  max-height: 85%;
   padding-inline: 2rem;
-  padding-top: 1.25rem;
+  padding-top: 1rem;
   font-style: normal;
   font-size: 22px;
   line-height: 150%;
   letter-spacing: 0.44px;
   color: #1c3a29;
+  overflow: auto;
 }
 
 .arrow_button {

--- a/frontend/src/app/components/Module5/Checkbox.module.css
+++ b/frontend/src/app/components/Module5/Checkbox.module.css
@@ -106,7 +106,7 @@
 
 .selectedRectangle {
   height: 114px;
-  width: 631px;
+  width: 100%;
   padding: 1.875rem 1.25rem;
   background-color: #bbd567;
   border-radius: 16px;

--- a/frontend/src/app/components/Module5/Checkbox.tsx
+++ b/frontend/src/app/components/Module5/Checkbox.tsx
@@ -12,7 +12,7 @@ const optionTexts: Record<string, { header: string; text: string; icon: string }
   },
   B: {
     header: "Speed Limit",
-    text: "Observe posted speed limits. That includes E-bikers too!",
+    text: "Observe posted speed limits. That includes E bikers too!",
     icon: "/module5/speedometer.svg",
   },
   C: {

--- a/frontend/src/app/components/Module5/Section2.tsx
+++ b/frontend/src/app/components/Module5/Section2.tsx
@@ -10,7 +10,7 @@ export default function SimpleWay() {
       <div className={styles.header_container}>
         <h2 className={styles.headerText}>OBEY TRAFFIC LAWS</h2>
         <p className={styles.headerSubtext}>
-          Check the boxes below to see laws even E-Bike riders must follow:
+          Check the boxes below to see laws even E Bike riders must follow:
         </p>
       </div>
       <Checkbox />

--- a/frontend/src/app/components/Module5/Section9.tsx
+++ b/frontend/src/app/components/Module5/Section9.tsx
@@ -34,7 +34,7 @@ export default function Section9() {
           <h1>REMEMBER:</h1>
           <div className={styles.box3}>
             <p>
-              Riding an e-bike is a{" "}
+              Riding an E bike is a{" "}
               <i>
                 <b>privilege</b>
               </i>

--- a/frontend/src/app/components/Module5/Section9.tsx
+++ b/frontend/src/app/components/Module5/Section9.tsx
@@ -12,7 +12,7 @@ export default function Section9() {
         <div className={styles.box1}>
           <p>
             <b>Local Regulations:</b> Always check for any local ordinances or regulations that may
-            apply in your specific area
+            apply in your specific area.
           </p>
         </div>
         <div className={styles.column2}>

--- a/frontend/src/app/components/ResetPasswordPanel.tsx
+++ b/frontend/src/app/components/ResetPasswordPanel.tsx
@@ -105,6 +105,8 @@ export default function ResetPasswordPanel() {
                 trackConfirmPassword();
               }}
               error={confirmPasswordError}
+              name="password"
+              autoComplete="current-password"
             />
           </div>
           {resetError && (

--- a/frontend/src/app/components/SignInPanel.module.css
+++ b/frontend/src/app/components/SignInPanel.module.css
@@ -120,6 +120,7 @@ a.secondary {
   gap: 0.5rem;
   white-space: nowrap;
   overflow: hidden;
+  max-width: 100%;
 }
 
 .built_by_tse a {

--- a/frontend/src/app/components/SignInPanel.tsx
+++ b/frontend/src/app/components/SignInPanel.tsx
@@ -115,7 +115,7 @@ export default function SignInPanel() {
           const errorCode = firebaseError.code ?? "unknown_error";
 
           if (errorCode === "auth/too-many-requests") {
-            setSignInError("Too many email verification requests. Please try again later.");
+            setSignInError("Too many email verification requests. Please try again in 1-2 minutes.");
           }
         });
     } else {

--- a/frontend/src/app/components/SignInPanel.tsx
+++ b/frontend/src/app/components/SignInPanel.tsx
@@ -161,6 +161,8 @@ export default function SignInPanel() {
             trackEmail(loginInfo.email);
           }}
           error={emailError}
+          name="username"
+          autoComplete="username"
         />
       </div>
       <div>
@@ -172,6 +174,8 @@ export default function SignInPanel() {
           onChange={(value) => {
             handleChange("password", value);
           }}
+          name="password"
+          autoComplete="current-password"
         />
         <a className={styles.forgotPassword} href="/forgotpassword">
           Forgot password?

--- a/frontend/src/app/components/SignInPanel.tsx
+++ b/frontend/src/app/components/SignInPanel.tsx
@@ -115,7 +115,9 @@ export default function SignInPanel() {
           const errorCode = firebaseError.code ?? "unknown_error";
 
           if (errorCode === "auth/too-many-requests") {
-            setSignInError("Too many email verification requests. Please try again in 1-2 minutes.");
+            setSignInError(
+              "Too many email verification requests. Please try again in 1-2 minutes.",
+            );
           }
         });
     } else {

--- a/frontend/src/app/components/TextBox.tsx
+++ b/frontend/src/app/components/TextBox.tsx
@@ -15,6 +15,8 @@ export type TextBoxProps = {
   onChange: (value: string) => void;
   onBlur?: () => void;
   error?: string;
+  name?: string;
+  autoComplete?: string;
 };
 
 export function TextBox({
@@ -28,6 +30,8 @@ export function TextBox({
   onChange,
   onBlur,
   error,
+  name,
+  autoComplete,
 }: TextBoxProps) {
   const [showPassword, setShowPassword] = useState(false);
   const [currentInputType, setCurrentInputType] = useState(type);
@@ -64,6 +68,8 @@ export function TextBox({
             type={currentInputType}
             placeholder={placeholder}
             className={styles.input}
+            name={name}
+            autoComplete={autoComplete}
           />
           {type === "password" && value.length > 0 && (
             <button
@@ -83,9 +89,11 @@ export function TextBox({
         </div>
       </form>
       <div className={styles.link}>{linkLabel && <a href={link}>{linkLabel}</a>}</div>
+
       <div className={styles.caption}>
         {caption && !error && value.length === 0 && <p>{caption}</p>}
       </div>
+
       <div>
         {error && (
           <div className={styles.error}>

--- a/frontend/src/app/components/VerifyEmail.tsx
+++ b/frontend/src/app/components/VerifyEmail.tsx
@@ -38,7 +38,7 @@ export default function VerifyEmail({ email }: VerifyEmailProps) {
 
           if (errorCode === "auth/too-many-requests") {
             setEmailResent("");
-            setVerificationError("Too many requests. Please try again later.");
+            setVerificationError("Too many requests. Please try again in 1-2 minutes.");
           }
         });
     } else {

--- a/frontend/src/app/components/WelcomePanel/WelcomePanel.tsx
+++ b/frontend/src/app/components/WelcomePanel/WelcomePanel.tsx
@@ -26,7 +26,7 @@ export default function WelcomePanel() {
           />
         </div>
         <div className={styles.positionedText}>
-          <h2>Welcome to the E-Bike Training Course!</h2>
+          <h2>Welcome to the E Bike Training Course!</h2>
         </div>
         <ul>
           {LOGOS.map((logo, index) => (

--- a/frontend/src/app/components/module1/Mod1Factor1.tsx
+++ b/frontend/src/app/components/module1/Mod1Factor1.tsx
@@ -9,7 +9,7 @@ export default function Mod1Factor1() {
     {
       icon: "/module1/road_icon.svg",
       content:
-        "Consider an efficient E bike with a long range, and ways to carry cargo (like tools for the road, school stuff, your sports gear, etc)",
+        "Consider an efficient E bike with a long range, and ways to carry cargo (like tools for the road, school stuff, your sports gear, etc).",
       imageUrl: "/module1/bike_commute.svg",
       iconAlt: "Road icon",
       imageAlt: "Bike for commuting",

--- a/frontend/src/app/components/module7/Suggestions.tsx
+++ b/frontend/src/app/components/module7/Suggestions.tsx
@@ -30,10 +30,15 @@ const Page5: React.FC = () => {
       title: "Review, discuss, and sign an E Bike Agreement between the guardian and teen. ",
       content: (
         <p>
-          Link to example agreement that can be downloaded and printed: <br />
-          <a href="https://electra.trekbikes.com/us/en_US/e-bike-agreement/">
-            (https://electra.trekbikes.com/us/en_US/e-bike-agreement/)
+          Link to example agreement that can be downloaded and printed: <br />(
+          <a
+            href="https://electra.trekbikes.com/us/en_US/e-bike-agreement/"
+            style={{ textDecoration: "underline" }}
+            target="_blank"
+          >
+            https://electra.trekbikes.com/us/en_US/e-bike-agreement/
           </a>
+          )
         </p>
       ),
     },

--- a/frontend/src/app/final-test/page.tsx
+++ b/frontend/src/app/final-test/page.tsx
@@ -7,7 +7,7 @@ import styles from "./final-test.module.css";
 export default function finalTest() {
   const questions: Question[] = [
     {
-      question: "Which class of e-bike is the fastest, reaching 28 mph?",
+      question: "Which class of E Bike is the fastest, reaching 28 mph?",
       options: ["Class 1", "Class 2", "Class 3", "Regular Bike"],
       correctAnswer: "C.",
       type: "single",
@@ -20,7 +20,7 @@ export default function finalTest() {
     },
     {
       question:
-        "True or False: If you modify an e-bike to go faster than is legal speed, you could get a ticket.",
+        "True or False: If you modify an E Bike to go faster than is legal speed, you could get a ticket.",
       options: ["True", "False"],
       correctAnswer: "A.",
       type: "single",
@@ -30,7 +30,7 @@ export default function finalTest() {
       options: [
         "Air in your tires, brakes, and chain",
         "The weather forecast",
-        "If your e-bike looks cool",
+        "If your E Bike looks cool",
         "How fast you can go",
       ],
       correctAnswer: "A.",
@@ -48,7 +48,7 @@ export default function finalTest() {
       type: "single",
     },
     {
-      question: "If your e-bike makes a weird noise, what should you do?",
+      question: "If your E Bike makes a weird noise, what should you do?",
       options: [
         "Ignore it, it will go away",
         "Ride faster to drown out the noise",
@@ -59,7 +59,7 @@ export default function finalTest() {
       type: "single",
     },
     {
-      question: "What is the best way to charge your e-bike battery?",
+      question: "What is the best way to charge your E Bike battery?",
       options: [
         "Follow the manufacturer's instructions",
         "Let it die completely before charging",

--- a/frontend/src/app/intro-video/page.tsx
+++ b/frontend/src/app/intro-video/page.tsx
@@ -51,7 +51,7 @@ export default function IntroVideo() {
     <ModuleGate module={0}>
       <main className={styles.main}>
         <div className={styles.wrapper}>
-          <h1 className={styles.title}>Welcome to the E-Bike Safety Course!</h1>
+          <h1 className={styles.title}>Welcome to the E Bike Safety Course!</h1>
           <div className={styles.container}>
             {/* prettier-ignore */}
             <svg width="856" height="384" viewBox="0 0 856 384" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -96,7 +96,7 @@ export default function IntroVideo() {
               </div>
               <div className={styles.description}>
                 <TypingAnimation
-                  text="Over the past three years, we've seen a <b>rise in serious e-bike injuries</b> in San Diego County, including areas like North County and UCSD. These injuries can be <b>serious and life-changing</b>, so it's important to know how to stay safe while riding."
+                  text="Over the past three years, we've seen a <b>rise in serious E Bike injuries</b> in San Diego County, including areas like North County and UCSD. These injuries can be <b>serious and life-changing</b>, so it's important to know how to stay safe while riding."
                   onFinishTyping={() => {
                     isTextLoaded(true);
                   }}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -19,8 +19,8 @@ const geistMono = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "UCSD Health | E-Bike Safety",
-  description: "UCSD Health E-Bike Safety Certification Website.",
+  title: "UCSD Health | E Bike Safety",
+  description: "UCSD Health E Bike Safety Certification Website.",
 };
 
 export default function RootLayout({

--- a/frontend/src/app/quiz/1/page.tsx
+++ b/frontend/src/app/quiz/1/page.tsx
@@ -20,7 +20,7 @@ export default function QuizPage1() {
     },
     {
       question:
-        "True or False: Riding an unclassified or bike modified to surpass the speed of its intended class can result in a fine or other penalties?",
+        "True or False: Riding an unclassified or bike modified to surpass the speed of its intended class can result in a fine or other penalties.",
       options: ["True", "False"],
       correctAnswer: "A.",
       type: "single",

--- a/frontend/src/app/quiz/3/page.tsx
+++ b/frontend/src/app/quiz/3/page.tsx
@@ -26,7 +26,7 @@ export default function QuizPage3() {
     },
     {
       question:
-        "True or False: Helmets can prevent serious head injury and permanent brain damage in bike accidents?",
+        "True or False: Helmets can prevent serious head injury and permanent brain damage in bike accidents.",
       options: ["True", "False"],
       correctAnswer: "A.",
       type: "single",

--- a/frontend/src/app/quiz/7/page.tsx
+++ b/frontend/src/app/quiz/7/page.tsx
@@ -8,7 +8,7 @@ export default function Quiz7() {
   const questions: Question[] = [
     {
       question:
-        "True or False: Parental or guardian models influence child and teen behavior patterns",
+        "True or False: Parental or guardian models influence child and teen behavior patterns.",
       options: ["True", "False"],
       correctAnswer: "A.",
       type: "single",


### PR DESCRIPTION
## Tracking Info

Resolves Isabel's and Sweekrit's Issues. Note I did not make any massive design choices and probably wont due to time constraints. That said here are my thoughts for the things I **DID NOT DO**
- "When not fully verified, allows user to access content" Did not run into this
- "Able to see flicker before loading homepage" takes too long to work on
- "Could make the right side centered" Do not think it is needed
- "May want to edit email template" Eshaan Will work on it
- "Back Buttons and Next Buttons" We had a massive designer conversation on this and this should be the best due to various sizes of screens
- "Wrong font for Class 1/2/3" Designer Changed it
- "Spacing looks off (likely b/c of default font-size setting in Chrome)" I don't know what I would change
- "Could consider only allowing email accounts with edu as the top level domain (i.e. [ibku@ucsd.edu](mailto:ibku@ucsd.edu)) Sign up/in/password forgot page probably don't look too good on phone"  I don't think we should?
- " Images from this screen were not fully loaded immediately (i.e. looked blank), could add loading text? and Would also be nice if you could type email → click tab → type password → click enter → it tries the email/password instead of needing to click" Another PR
- "Could be nice to click on the dots on the bottom instead of only using the (<) and (>) buttons" Already occurs
- "Green circle buttons are not consistent. In module 4, they change color, while in module 5, they become bigger and change color only for hover instead of click" Design Change I dont want to do 

## Changes

<!-- What changes did you make? -->


**I DID THESE**

- "In the sign up/sign in page, unlike the UC San Diego + Scripps logo, the "Built for free by Triton Software Engineering" does not have a fixed position and overflows into the other half of the screen. It's a relatively niche scenario, but it could be good restricting it for niche cases." Made it have a max width
- "Again, a niche scenario, but for the "click to resend" we should have a time indicator (maybe smth like "Please wait 2-3 minutes") show in addition to the "too many requests" just to provide a quantifiable time between sends. The success screen does a good job of this." Changed the wording to have 1-2 minutes
- Changed all occurrences of E-bike or e-bike or e bike to E Bike
- "No spacing on the right (likely b/c of default font-size setting in Chrome)" Fixed Checkbox component
- "Text outside of box (likely b/c of default font-size setting in Chrome)" Made the text scrollable
- "Could add a period (the other two boxes not shown below have punctuation)" fixed
- "Missing underline for link" fixed
- "Would be nice to save the email as a username automatically" Fixed, look at code and please test it just in case



## Testing

<!-- How did you confirm your changes worked? -->

All local host tests

## Confirmation of Change

<!-- Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change. -->

I am on a flight and cannot do so right now. So please test it out for me!
